### PR TITLE
Added Reverse Control Powerup

### DIFF
--- a/Super-Pong/Assets/PowerUps/ReverseControls.prefab
+++ b/Super-Pong/Assets/PowerUps/ReverseControls.prefab
@@ -1,0 +1,135 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5104225036528839054
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5104225036528839042}
+  - component: {fileID: 5104225036528839043}
+  - component: {fileID: 5104225036528839052}
+  - component: {fileID: 5104225036528839053}
+  m_Layer: 0
+  m_Name: ReverseControls
+  m_TagString: ReverseControls
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5104225036528839042
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5104225036528839054}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.05, y: -1.94, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &5104225036528839043
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5104225036528839054}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 0.9245283, g: 0.92255944, b: 0.039248828, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!50 &5104225036528839052
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5104225036528839054}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 6200000, guid: 6ed1941756978d74a84c457573e1f84f, type: 2}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!61 &5104225036528839053
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5104225036528839054}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0

--- a/Super-Pong/Assets/PowerUps/ReverseControls.prefab.meta
+++ b/Super-Pong/Assets/PowerUps/ReverseControls.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 24b1ef3900f2b404b89981e4e1a40d48
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Super-Pong/Assets/Scenes/SampleScene.unity
+++ b/Super-Pong/Assets/Scenes/SampleScene.unity
@@ -1820,4 +1820,5 @@ MonoBehaviour:
   PowerUpList:
   - {fileID: 5104225036528839054, guid: c91b883b7ae05874c8073cd33195249b, type: 3}
   - {fileID: 261403770186411088, guid: fae31a29ca400a243805cde0febb0ee9, type: 3}
+  - {fileID: 5104225036528839054, guid: 24b1ef3900f2b404b89981e4e1a40d48, type: 3}
   CurrentPowerUpList: []

--- a/Super-Pong/Assets/Scripts/Paddles.cs
+++ b/Super-Pong/Assets/Scripts/Paddles.cs
@@ -11,6 +11,8 @@ public class Paddles : MonoBehaviour
     public Vector3 startPosition;
     public Vector3 initialSize;
 
+    bool reverse = false;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -29,6 +31,11 @@ public class Paddles : MonoBehaviour
             movement = Input.GetAxisRaw("Vertical2");   
         }
         rb.velocity = new Vector2(rb.velocity.x, movement * speed);
+
+        if(reverse == true)
+        {
+            reverseControls();
+        }
     }
 
     public void Reset()
@@ -37,4 +44,21 @@ public class Paddles : MonoBehaviour
         transform.position = startPosition;
         transform.localScale = initialSize;
     }
+
+    //Added by Ian in branch ReverseControls
+    public bool reverseControls()
+    {
+        reverse = true;
+        if (isLeftPaddle == true)
+        {
+            movement = -Input.GetAxisRaw("Vertical");
+        }
+        if (isLeftPaddle == false)
+        {
+            movement = -Input.GetAxisRaw("Vertical2");
+        }
+        rb.velocity = new Vector2(rb.velocity.x, movement * speed);
+        return true;
+    }
+
 }

--- a/Super-Pong/Assets/Scripts/PowerupManager.cs
+++ b/Super-Pong/Assets/Scripts/PowerupManager.cs
@@ -54,7 +54,11 @@ public class PowerupManager : MonoBehaviour
                 Destroy(a.gameObject);
                 CurrentNumberOfPowerups--;
                 break;
-            case "ReverseControl":
+            case "ReverseControls":
+                //gameObject.GetComponent<Paddles>().reverseControls();
+                currentPlayer.GetComponent<Paddles>().reverseControls();
+                Destroy(a.gameObject);
+                CurrentNumberOfPowerups--;
                 break;
         }
     }

--- a/Super-Pong/ProjectSettings/TagManager.asset
+++ b/Super-Pong/ProjectSettings/TagManager.asset
@@ -7,6 +7,7 @@ TagManager:
   - Ball
   - WidePaddle
   - SpeedUp
+  - ReverseControls
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Unity Changes: Created prefab for powerup. Added prefab to powerup list.

Script Changes: Made changes to paddles script and powerup manager. Occupied switch case for Reverse Controls. The current player's controls are reversed. Created a method in paddles that reverses the controls. It is activated if a bool is true. When the method is called in PowerupManager, the paddles script recognizes the bool as true and reverses the controls.